### PR TITLE
Issue #9: Add WebSocket Support

### DIFF
--- a/cometd-nodejs-client.js
+++ b/cometd-nodejs-client.js
@@ -154,5 +154,8 @@ module.exports = {
         window.XMLHttpRequest.HEADERS_RECEIVED = 2;
         window.XMLHttpRequest.LOADING = 3;
         window.XMLHttpRequest.DONE = 4;
+
+        // WebSocket support
+        window.WebSocket = require('ws');
     }
 };

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
   },
   "devDependencies": {
     "mocha": "*"
+  },
+  "dependencies": {
+    "ws": "^6.0.0"
   }
 }


### PR DESCRIPTION
Adds WebSocket support for the Node.js CometD client using the [ws](https://www.npmjs.com/package/ws) package.

The [ws](https://www.npmjs.com/package/ws) implements its WebSocket class using the [WebSocket interface](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) for the WebSocket class found on the browser.