### PR TITLE
feat: type definitions, es modules usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/
 
 node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Therefore, you need to install the CometD JavaScript Client, version 3.1.2 or gr
 npm install cometd
 ```
 
-### Usage
+### Usage (CommonJS)
 
 ```javascript
 // Run the adapter code that implements XMLHttpRequest.
@@ -36,6 +36,18 @@ require('cometd-nodejs-client').adapt();
 var lib = require('cometd');
 var cometd = new lib.CometD();
 ...
+```
+
+### Usage (ES Modules)
+
+```javascript
+import { CometD } from 'cometd';
+import { adapt } from 'cometd-nodejs-client';
+// Shim XMLHTTPRequest for Node.js (required by CometD).
+adapt();
+
+// Your normal CometD client application here.
+const client = new CometD();
 ```
 
 See [here](https://github.com/cometd/cometd-javascript/blob/master/README.md) for an example CometD client application.

--- a/cometd-nodejs-client.d.ts
+++ b/cometd-nodejs-client.d.ts
@@ -1,0 +1,12 @@
+export interface Proxy {
+  uri?: string;
+  includes?: string[];
+  excludes?: string[];
+}
+
+export interface Options {
+  logLevel?: "debug" | "info";
+  httpProxy: Proxy;
+}
+
+export function adapt(options?: Options): void;

--- a/cometd-nodejs-client.d.ts
+++ b/cometd-nodejs-client.d.ts
@@ -1,4 +1,19 @@
-export interface Proxy {
+/*
+ * Copyright (c) 2017-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface HttpProxy {
   uri?: string;
   includes?: string[];
   excludes?: string[];
@@ -6,7 +21,7 @@ export interface Proxy {
 
 export interface Options {
   logLevel?: "debug" | "info";
-  httpProxy?: Proxy;
+  httpProxy?: HttpProxy;
 }
 
 export function adapt(options?: Options): void;

--- a/cometd-nodejs-client.d.ts
+++ b/cometd-nodejs-client.d.ts
@@ -6,7 +6,7 @@ export interface Proxy {
 
 export interface Options {
   logLevel?: "debug" | "info";
-  httpProxy: Proxy;
+  httpProxy?: Proxy;
 }
 
 export function adapt(options?: Options): void;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "license": "Apache-2.0",
   "main": "cometd-nodejs-client.js",
+  "types": "cometd-nodejs-client.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/cometd/cometd-nodejs-client.git"


### PR DESCRIPTION
This PR:

1. Adds a set of TypeScript type definitions (`.d.ts`) to the library.
2. Adds example code to the readme for using the library via ES modules.

### Testing

How I tested these type definitions locally:

1. Convert all `test/` files from `.js` -> `.ts`
2. Add `@types/node`, `@types/mocha`, `ts-node`, `typescript` packages
3. Convert all top-level variables in tests from `const` -> `let`
4. `mocha -r ts-node/register test/*.ts`
5. Expect tests to pass!
